### PR TITLE
Remove BHOP_MUSIC_BASE to make modules relocatable

### DIFF
--- a/bhop.s
+++ b/bhop.s
@@ -20,6 +20,7 @@ channel_index: .byte $00
 scratch_byte: .byte $00
 
         .segment BHOP_RAM_SEGMENT
+music_header_ptr: .word $0000
 tempo_counter: .word $0000
 tempo_cmp: .word $0000
 tempo: .byte $00
@@ -131,6 +132,18 @@ effect_dac_buffer: .byte $00
         sta bhop_ptr+1
 .endmacro
 
+.macro prepare_ptr_with_fixed_offset address, offset
+        prepare_ptr address
+        ldy #offset
+        lda (bhop_ptr), y
+        pha
+        iny
+        lda (bhop_ptr), y
+        sta bhop_ptr+1
+        pla
+        sta bhop_ptr
+.endmacro
+
 ; add a signed byte, stored in value, to a 16bit word
 ; addressed by (bhop_ptr), y
 ; this is used in a few places, notably pitch bend effects
@@ -166,9 +179,15 @@ positive:
 .endproc
 
 ; param: song index (a)
+;        Low byte pointer to the music data (x)
+;        High byte pointer to the music data (y)
 .proc bhop_init
         ; preserve parameters
         pha ; song index
+
+        ; initialize bhop_ptr with the song header
+        stx music_header_ptr
+        sty music_header_ptr+1
 
 .if ::BHOP_PATTERN_BANKING
         lda module_bank
@@ -185,7 +204,7 @@ positive:
         sta groove_index
 
         ; switch to the requested song
-        prepare_ptr BHOP_MUSIC_BASE + FtModuleHeader::song_list
+        prepare_ptr_with_fixed_offset music_header_ptr, FtModuleHeader::song_list
 
         pla
         asl ; song list is made of words
@@ -195,6 +214,14 @@ positive:
         iny
         lda (bhop_ptr), y
         sta song_ptr+1
+
+.if ::BHOP_PATTERN_BANKING
+        ; load the module flags from the header before changing the pointer
+        prepare_ptr music_header_ptr
+        ldy #FtModuleHeader::flags
+        lda (bhop_ptr), y
+        sta module_flags
+.endif
 
         ; load speed and tempo from the requested song
         prepare_ptr song_ptr
@@ -218,9 +245,6 @@ song_uses_groove:
         ldy #SongInfo::pattern_length
         lda (bhop_ptr), y
         sta row_cmp
-
-        lda BHOP_MUSIC_BASE + FtModuleHeader::flags
-        sta module_flags
 
         ; If this song has grooves enabled, then apply the first groove right away
         jsr update_groove
@@ -340,7 +364,7 @@ loop:
         lda groove_index
         beq done
 
-        prepare_ptr BHOP_MUSIC_BASE + FtModuleHeader::groove_list
+        prepare_ptr_with_fixed_offset music_header_ptr, FtModuleHeader::groove_list
 
         ldy groove_position
         lda (bhop_ptr), y
@@ -1192,7 +1216,7 @@ no_wrap:
 ;   channel_index points to desired channel
 ;   channel_selected_instrument[channel_index] contains desired instrument index
 .proc load_instrument
-        prepare_ptr BHOP_MUSIC_BASE + FtModuleHeader::instrument_list
+        prepare_ptr_with_fixed_offset music_header_ptr, FtModuleHeader::instrument_list
         ldx channel_index
         lda channel_selected_instrument, x
         asl ; select one word
@@ -2412,7 +2436,7 @@ next:
         .endif
 
         ; using the current note, read the sample table
-        prepare_ptr BHOP_MUSIC_BASE + FtModuleHeader::sample_list
+        prepare_ptr_with_fixed_offset music_header_ptr, FtModuleHeader::sample_list
         lda channel_base_note + DPCM_INDEX
 
         sta scratch_byte
@@ -2456,8 +2480,11 @@ skip_dac:
         lda (bhop_ptr), y
         ; this is the index into the samples table, here it is pre-multiplied
         ; so we can use it directly
+        ; save the y value since it is scratched by the prepare_ptr
+        pha
+        prepare_ptr_with_fixed_offset music_header_ptr, FtModuleHeader::samples
+        pla
         tay
-        prepare_ptr BHOP_MUSIC_BASE + FtModuleHeader::samples
         ; the sample table should contain, in order:
         ; - location byte
         ; - size byte

--- a/bhop/config.inc
+++ b/bhop/config.inc
@@ -12,13 +12,6 @@ __BHOP_CONFIG = 1
 ; are temporary, so feel free to allocate them in your scratch region and
 ; clobber them freely between calls to bhop_play.
 
-.import bhop_music_data
-
-; To play a module, export "music.asm" from FamiTracker, and
-; place it in memory here. Ensure this memory is paged in
-; during bhop_init and bhop_play.
-BHOP_MUSIC_BASE = bhop_music_data
-
 ; Banking support. Disabled by default, as the relevant
 ; mapper code is project specific.
 BHOP_DPCM_BANKING = 0

--- a/demos/2a03/prg/bhop_mmc3_config.inc
+++ b/demos/2a03/prg/bhop_mmc3_config.inc
@@ -11,9 +11,6 @@ __BHOP_CONFIG = 1
 .define BHOP_RAM_SEGMENT "RAM"
 .define BHOP_ZP_SEGMENT "ZEROPAGE"
 
-.import bhop_music_data
-
-BHOP_MUSIC_BASE = bhop_music_data
 BHOP_DPCM_BANKING = 1
 BHOP_PATTERN_BANKING = 1
 

--- a/demos/2a03/prg/main.s
+++ b/demos/2a03/prg/main.s
@@ -21,63 +21,61 @@ NmiCounter: .byte $00
         .segment "CHR1"
         .incbin "../../common/bnuuy_obj.chr"
 
-        .export start, nmi, irq, bhop_music_data
-        
-bhop_music_data = $A000
+        .export start, nmi, irq
 
         .segment "MUSIC_0"
-        .scope MODULE_0
+        .proc MODULE_0
         .include "../music/in_this_together.asm"
         ;.include "../music/sxx.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_1"
-        .scope MODULE_1
+        .proc MODULE_1
         .include "../music/virus-busting.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_2"
-        .scope MODULE_2
+        .proc MODULE_2
         .include "../music/world-1-1.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_3"
-        .scope MODULE_3
+        .proc MODULE_3
         .include "../music/yakra.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_4"
-        .scope MODULE_4
+        .proc MODULE_4
         .include "../music/nsmb.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_5"
-        .scope MODULE_5
+        .proc MODULE_5
         .include "../music/sanctuary.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_6"
-        .scope MODULE_6
+        .proc MODULE_6
         .include "../music/gato.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_7"
-        .scope MODULE_7
+        .proc MODULE_7
         .include "../music/simian_segue.asm"
-        .endscope
+        .endproc
 
         .segment "CODE"
 
-;                                Bank  Track#                          Title                        Artist
-;                                 ---     ---   ----------------------------  ----------------------------
-song_itt:       music_track         0,      0,  "Ikenfell - In This Together",           "aivi & surasshu"
-song_virus:     music_track         1,      0,        "MMBN. - Virus Busting",              "Yoshino Aoki"
-song_smb:       music_track         2,      0, "Super Mario Bros - World 1-1",                "Koji Kondo"
-song_yakra:     music_track         3,      0, "Chrono Trigger - Boss Battle",          "Yasunori Mitsuda"
-song_nsmb:      music_track         4,      0,   "New Super Mario Bros - 1-1",                "Koji Kondo"
-song_sanctuary: music_track         5,      0,        "Earthbound - Guardian",      "K. Suzuki, H. Tanaka"
-song_gato:      music_track         6,      0,      "Chrono Trigger - Battle",          "Yasunori Mitsuda"
-song_simian:    music_track         7,      0,           "DKC - Simian Segue",           "Eveline Fischer"
+;                                Address               Bank   Track#                          Title                        Artist
+;                               --------                ---      ---   ----------------------------  ----------------------------
+song_itt:       music_track     MODULE_0,  <.bank(MODULE_0),      0,  "Ikenfell - In This Together",           "aivi & surasshu"
+song_virus:     music_track     MODULE_1,  <.bank(MODULE_1),      0,        "MMBN. - Virus Busting",              "Yoshino Aoki"
+song_smb:       music_track     MODULE_2,  <.bank(MODULE_2),      0, "Super Mario Bros - World 1-1",                "Koji Kondo"
+song_yakra:     music_track     MODULE_3,  <.bank(MODULE_3),      0, "Chrono Trigger - Boss Battle",          "Yasunori Mitsuda"
+song_nsmb:      music_track     MODULE_4,  <.bank(MODULE_4),      0,   "New Super Mario Bros - 1-1",                "Koji Kondo"
+song_sanctuary: music_track     MODULE_5,  <.bank(MODULE_5),      0,        "Earthbound - Guardian",      "K. Suzuki, H. Tanaka"
+song_gato:      music_track     MODULE_6,  <.bank(MODULE_6),      0,      "Chrono Trigger - Battle",          "Yasunori Mitsuda"
+song_simian:    music_track     MODULE_7,  <.bank(MODULE_7),      0,           "DKC - Simian Segue",           "Eveline Fischer"
 
 music_track_table:
         .addr song_itt

--- a/demos/2a03/prg/mmc3.cfg
+++ b/demos/2a03/prg/mmc3.cfg
@@ -77,6 +77,7 @@ SEGMENTS {
    BSS:        load = RAM,                 type = bss, align = $100, define = yes;
    RAM:        load = RAM,                 type = bss, start = $0300;
    HEADER:     load = HDR,                 type = ro,  align = $10;
+# Combine Music 6 and Music 7 into the same PRG bank to test variable address loading
    MUSIC_0:    load = PRG0,                type = ro;
    MUSIC_1:    load = PRG1,                type = ro;
    MUSIC_2:    load = PRG2,                type = ro;
@@ -84,7 +85,7 @@ SEGMENTS {
    MUSIC_4:    load = PRG4,                type = ro;
    MUSIC_5:    load = PRG5,                type = ro;
    MUSIC_6:    load = PRG6,                type = ro;
-   MUSIC_7:    load = PRG7,                type = ro;
+   MUSIC_7:    load = PRG6,                type = ro;
    MUSIC_8:    load = PRG8,                type = ro;
    MUSIC_9:    load = PRG9,                type = ro;
    MUSIC_10:   load = PRG10,               type = ro;

--- a/demos/common/player.inc
+++ b/demos/common/player.inc
@@ -1,4 +1,5 @@
 .struct MusicTrack
+        ModulePtr .word
         BankNumber .byte
         TrackNumber .byte
         TitleStringPtr .word
@@ -16,8 +17,9 @@
 
 ; This macro helps to make the track list less stupid
 
-.macro music_track bank_number, track_number, title_string, artist_string
+.macro music_track module_ptr, bank_number, track_number, title_string, artist_string
 .scope
+.addr module_ptr
 .byte bank_number
 .byte track_number
 .addr title_str

--- a/demos/common/player.s
+++ b/demos/common/player.s
@@ -217,6 +217,14 @@ FancyTextPtr := ScratchPtr
 
         ldy #MusicTrack::TrackNumber
         lda (TrackPtr), y
+        pha ; store the track number and reload it after loading the address for the song
+        ldy #MusicTrack::ModulePtr
+        lda (TrackPtr), y
+        tax ; lo ptr for the module address
+        iny
+        lda (TrackPtr), y
+        tay ; hi ptr for the module address
+        pla
         jsr bhop_init
         rts
 .endproc

--- a/demos/mmc5/prg/bhop_mmc5_config.inc
+++ b/demos/mmc5/prg/bhop_mmc5_config.inc
@@ -10,9 +10,6 @@ __BHOP_CONFIG = 1
 .define BHOP_RAM_SEGMENT "RAM"
 .define BHOP_ZP_SEGMENT "ZEROPAGE"
 
-.import bhop_music_data
-
-BHOP_MUSIC_BASE = bhop_music_data
 BHOP_DPCM_BANKING = 1
 
 .if ::BHOP_DPCM_BANKING

--- a/demos/mmc5/prg/main.s
+++ b/demos/mmc5/prg/main.s
@@ -19,21 +19,19 @@ NmiCounter: .byte $00
         .segment "CHR1"
         .incbin "../../common/bnuuy_obj.chr"
 
-        .export start, nmi, irq, bhop_music_data
-        
-bhop_music_data = $A000
+        .export start, nmi, irq
 
         .segment "MUSIC_0"
-        .scope MODULE_0
+        .proc MODULE_0
         .include "../music/brain_age.asm"
-        .endscope
+        .endproc
 
 
         .segment "CODE"
 
-;                                Bank  Track#                          Title                        Artist
-;                                 ---     ---   ----------------------------  ----------------------------
-song_brain_age:     music_track         0,      0, "Brain Age - Menu",           "M. Hamano, A. Nakatsuka"
+;                                  Address              Bank  Track#                          Title                        Artist
+;                                 --------               ---     ---   ----------------------------  ----------------------------
+song_brain_age:     music_track  MODULE_0,  <.bank(MODULE_0),      0,            "Brain Age - Menu",     "M. Hamano, A. Nakatsuka"
 
 music_track_table:
         .addr song_brain_age

--- a/demos/zsaw_mmc3/prg/bhop_mmc3_config.inc
+++ b/demos/zsaw_mmc3/prg/bhop_mmc3_config.inc
@@ -10,9 +10,6 @@ __BHOP_CONFIG = 1
 .define BHOP_RAM_SEGMENT "RAM"
 .define BHOP_ZP_SEGMENT "ZEROPAGE"
 
-.import bhop_music_data
-
-BHOP_MUSIC_BASE = bhop_music_data
 BHOP_DPCM_BANKING = 1
 BHOP_PATTERN_BANKING = 1
 

--- a/demos/zsaw_mmc3/prg/main.s
+++ b/demos/zsaw_mmc3/prg/main.s
@@ -21,44 +21,42 @@ NmiCounter: .byte $00
         .segment "CHR1"
         .incbin "../../common/bnuuy_obj.chr"
 
-        .export start, demo_nmi, bhop_music_data
-        
-bhop_music_data = $A000
+        .export start, demo_nmi
 
         .segment "MUSIC_0"
-        .scope MODULE_0
+        .proc MODULE_0
         .include "../music/heatdeath.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_1"
-        .scope MODULE_1
+        .proc MODULE_1
         .include "../music/tactus.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_2"
-        .scope MODULE_2
+        .proc MODULE_2
         .include "../music/tcg.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_3"
-        .scope MODULE_3
+        .proc MODULE_3
         .include "../music/mimiga.asm"
-        .endscope
+        .endproc
 
         .segment "MUSIC_4"
-        .scope MODULE_4
+        .proc MODULE_4
         .include "../music/in_another_world.asm"
-        .endscope
+        .endproc
 
         .segment "CODE"
 
-;                            Bank  Track#                         Title                        Artist
-;                             ---     ---  ----------------------------  ----------------------------
-song_heat_death: music_track    0,      0,        "Heat Death - Smooth",                   "zeta0134"
-song_tactus:     music_track    1,      0,              "Tactus - Demo",                   "zeta0134"
-song_tcg:        music_track    2,      0,        "Pokemon TCG - Diary",           "Ichiro Shimakura"
-song_mimiga:     music_track    3,      0,   "Cave Story - Mimiga Town",              "Daisuke Amaya"
-song_iaw:        music_track    4,      1,           "in another world",                    "Persune"
+;                                Address             Bank   Track#                         Title                       Artist
+;                               --------              ---      ---   ----------------------------  ---------------------------
+song_heat_death: music_track    MODULE_0, <.bank(MODULE_0),      0,        "Heat Death - Smooth",                   "zeta0134"
+song_tactus:     music_track    MODULE_1, <.bank(MODULE_1),      0,              "Tactus - Demo",                   "zeta0134"
+song_tcg:        music_track    MODULE_2, <.bank(MODULE_2),      0,        "Pokemon TCG - Diary",           "Ichiro Shimakura"
+song_mimiga:     music_track    MODULE_3, <.bank(MODULE_3),      0,   "Cave Story - Mimiga Town",              "Daisuke Amaya"
+song_iaw:        music_track    MODULE_4, <.bank(MODULE_4),      1,           "in another world",                    "Persune"
 
 music_track_table:
         .addr song_heat_death

--- a/demos/zsaw_mmc3/prg/mmc3.cfg
+++ b/demos/zsaw_mmc3/prg/mmc3.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
    RAM:        load = RAM,                 type = bss, start = $0300;
    HEADER:     load = HDR,                 type = ro,  align = $10;
    MUSIC_0:    load = PRG0,                type = ro;
-   MUSIC_1:    load = PRG1,                type = ro;
+   MUSIC_1:    load = PRG0,                type = ro;
    MUSIC_2:    load = PRG2,                type = ro;
    MUSIC_3:    load = PRG3,                type = ro;
    MUSIC_4:    load = PRG4,                type = ro;

--- a/demos/zsaw_nrom/prg/bhop_nrom_config.inc
+++ b/demos/zsaw_nrom/prg/bhop_nrom_config.inc
@@ -10,9 +10,6 @@ __BHOP_CONFIG = 1
 .define BHOP_RAM_SEGMENT "RAM"
 .define BHOP_ZP_SEGMENT "ZEROPAGE"
 
-.import bhop_music_data
-
-BHOP_MUSIC_BASE = bhop_music_data
 BHOP_DPCM_BANKING = 0
 
 .if ::BHOP_DPCM_BANKING

--- a/demos/zsaw_nrom/prg/main.s
+++ b/demos/zsaw_nrom/prg/main.s
@@ -20,15 +20,16 @@ NmiCounter: .byte $00
         .incbin "../../common/bnuuy_obj.chr"
 
         .segment "PRG0_8000"
-        .export start, demo_nmi, bhop_music_data
+        .export start, demo_nmi
 
-bhop_music_data:
+.proc MODULE_0
         .include "../music/zsaw_demo_tracks.asm"
+.endproc
 
-;                            Bank  Track#                         Title                        Artist
-;                             ---     ---  ----------------------------  ----------------------------
-song_heat_death: music_track    0,      0,        "Heat Death - Smooth",                   "zeta0134"
-song_tactus:     music_track    0,      1,              "Tactus - Demo",                   "zeta0134"
+;                                Address              Bank  Track#                          Title                        Artist
+;                               --------               ---     ---   ----------------------------  ----------------------------
+song_heat_death: music_track    MODULE_0, <.bank(MODULE_0),      0,        "Heat Death - Smooth",                   "zeta0134"
+song_tactus:     music_track    MODULE_0, <.bank(MODULE_0),      1,              "Tactus - Demo",                   "zeta0134"
 
 music_track_table:
         .addr song_heat_death

--- a/demos/zsaw_nrom/prg/nrom.cfg
+++ b/demos/zsaw_nrom/prg/nrom.cfg
@@ -4,7 +4,7 @@ MEMORY {
     RAM:       start = $0300, size = $500,  type = rw;
     PRGRAM:    start = $6000, size = $2000,  type = rw;
     HDR:       start = $0000, size = $10,   type = ro, file = %O, fill = yes;
-    PRG_8000:  start = $8000, size = $4000, type = ro, file = %O, fill = yes, fillval = $FF;
+    PRG_8000:  start = $8000, size = $4000, type = ro, file = %O, fill = yes, fillval = $FF, bank = 0;
     PRG_C000:  start = $C000, size = $4000, type = ro, file = %O, fill = yes, fillval = $FF;
     CHR0:      start = $0000, size = $1000, type = ro, file = %O, fill = yes, fillval = $00;
     CHR1:      start = $0000, size = $1000, type = ro, file = %O, fill = yes, fillval = $00;


### PR DESCRIPTION
Changes bhop_init to take the address of the module as the parameters in x/y.

Updates all the demos to account for this change as well