### PR TITLE
Various effects fix

### DIFF
--- a/bhop.s
+++ b/bhop.s
@@ -593,7 +593,18 @@ done_advancing_rows:
 ; prep:
 ; - channel_index is set to desired channel
 .proc advance_channel_row
+        ; see CChannelHandler::PlayNote() in Dn-FT
+        ; check first if we still have lingering delay from the previous row
         ldx channel_index
+        lda effect_note_delay, x
+        beq skip_handle_delay
+        ; see CChannelHandler::HandleDelay() in Dn-FT
+        ; if so, advance one row to sync
+        lda #0
+        sta effect_note_delay, x
+        jsr advance_channel_row
+skip_handle_delay:
+        ldx channel_index ; the recursive call may have clobbered X
         lda channel_row_delay_counter, x
         cmp #0
         jne skip

--- a/bhop.s
+++ b/bhop.s
@@ -2456,9 +2456,9 @@ skip_pitch:
         iny
         sta scratch_byte
         lda effect_dac_buffer ; check for Zxx
-        bmi skip_dac ; != -1? then it was already written
+        bpl skip_dac ; != -1? then it was already written
         lda scratch_byte
-        bpl skip_dac
+        bmi skip_dac
         sta $4011
 skip_dac:
         lda #$FF


### PR DESCRIPTION
This PR aims to fix the following various bugs in effects.

- Note delay parameter overflow
  - When a Gxx command's parameter exceeds the row's tick length, it causes subsequent rows to be delayed further, putting the entire channel's row timing out of order until the next pattern frame.
  - FT fixes this upon each new row by resetting the delay value of a channel and syncing to the current row.
- Zxx/instrument $4011 mutex bug
  - The logic to determine whether Zxx has fired prior to an instrument has been initially implemented inverted.