### PR TITLE
Allow for external configuration so users don't need to edit config.inc

### DIFF
--- a/bhop/config.inc
+++ b/bhop/config.inc
@@ -1,12 +1,20 @@
 .ifndef __BHOP_CONFIG
 __BHOP_CONFIG = 1
 
+.include "option_util.inc"
+
 ; Configuration variables, adjust these to taste for your specific project
 
 ; Where should BHOP live?
+.if .xmatch(BHOP_PLAYER_SEGMENT, "BHOP_PLAYER_SEGMENT")
 .define BHOP_PLAYER_SEGMENT "PRG_8000"
+.endif
+.if .xmatch(BHOP_RAM_SEGMENT, "BHOP_RAM_SEGMENT")
 .define BHOP_RAM_SEGMENT "RAM"
+.endif
+.if .xmatch(BHOP_ZP_SEGMENT, "BHOP_ZP_SEGMENT")
 .define BHOP_ZP_SEGMENT "ZEROPAGE"
+.endif
 
 ; Note: bhop currently requires just 6 bytes of zeropage. ALL of these bytes
 ; are temporary, so feel free to allocate them in your scratch region and
@@ -14,7 +22,7 @@ __BHOP_CONFIG = 1
 
 ; Banking support. Disabled by default, as the relevant
 ; mapper code is project specific.
-BHOP_PATTERN_BANKING = 0
+__bool_option BHOP_PATTERN_BANKING
 
 .if ::BHOP_PATTERN_BANKING
 .import bhop_apply_music_bank
@@ -27,7 +35,7 @@ BHOP_PATTERN_SWITCH_ROUTINE = bhop_apply_music_bank
 ; A register before calling. It does not expect any registers
 ; or flags to be preserved.
 
-BHOP_DPCM_BANKING = 0
+__bool_option BHOP_DPCM_BANKING
 
 .if ::BHOP_DPCM_BANKING
 .import bhop_apply_dpcm_bank
@@ -36,33 +44,33 @@ BHOP_DPCM_SWITCH_ROUTINE = bhop_apply_dpcm_bank
 
 ; Options for different features that can be disabled to save space
 
-BHOP_DELAYED_RELEASE_ENABLED = 1
+__bool_option BHOP_DELAYED_RELEASE_ENABLED, 1
 
-BHOP_PITCH_DETUNE_CLAMP_ENABLED = 1
+__bool_option BHOP_PITCH_DETUNE_CLAMP_ENABLED, 1
 
 ; Toggle the following flags to enable various expansion channel types
 
-BHOP_MMC5_ENABLED = 0
+__bool_option BHOP_MMC5_ENABLED
 
-BHOP_VRC6_ENABLED = 0
+__bool_option BHOP_VRC6_ENABLED
     ; VRC6 variants for compatible mappers
     ; Only enable one of these at a time
-    BHOP_VRC6_MAPPER24 = 0
-    BHOP_VRC6_RAINBOW = 0
+    __bool_option BHOP_VRC6_MAPPER24
+    __bool_option BHOP_VRC6_RAINBOW
 
 ; virtual Z channel audio, mutually exclusive from DPCM sample playback
 ; concurrent Z-Saw and ZPCM is not supported (yet?).
 
-BHOP_ZSAW_ENABLED = 0   ; generates custom waveforms using looping DPCM samples
+__bool_option BHOP_ZSAW_ENABLED   ; generates custom waveforms using looping DPCM samples
 
-BHOP_ZPCM_ENABLED = 0   ; outputs expansion audio to DPCM via inc $4011
+__bool_option BHOP_ZPCM_ENABLED   ; outputs expansion audio to DPCM via inc $4011
     ; If using an advanced mapper that supports ZPCM, normally the DPCM channel is
     ; suppressed by the ZPCM activity. If you want to play DPCM samples, ZPCM must
     ; be temporarily disabled. Enable this feature if you want bhop to support this
     ; behavior, and provide your project-specific mechanism to temporarily disable
     ; and enable ZPCM updates by exporting the two symbols below. These routines
     ; will accept no arguments, and may clobber any registers.
-    BHOP_ZPCM_CONFLICT_AVOIDANCE = 0
+    __bool_option BHOP_ZPCM_CONFLICT_AVOIDANCE
 
     .if ::BHOP_ZPCM_CONFLICT_AVOIDANCE
     .import bhop_enable_zpcm, bhop_disable_zpcm
@@ -73,14 +81,14 @@ BHOP_ZPCM_ENABLED = 0   ; outputs expansion audio to DPCM via inc $4011
 ; The following chips below are not yet implemented
 ; if you enable them, they will not read nor write any data associated
 
-BHOP_N163_ENABLED = 0
-BHOP_FDS_ENABLED = 0
-BHOP_S5B_ENABLED = 0
-BHOP_VRC7_ENABLED = 0
+__bool_option BHOP_N163_ENABLED
+__bool_option BHOP_FDS_ENABLED
+__bool_option BHOP_S5B_ENABLED
+__bool_option BHOP_VRC7_ENABLED
 
 ; Toggle to enable multiple expansion audio chips at once
 ; at the cost of needing a byte in bss to determine which expansion audio types are used
 
-BHOP_MULTICHIP = 0
+__bool_option BHOP_MULTICHIP
 
 .endif ; __BHOP_CONFIG

--- a/bhop/config.inc
+++ b/bhop/config.inc
@@ -25,7 +25,9 @@ __BHOP_CONFIG = 1
 __bool_option BHOP_PATTERN_BANKING
 
 .if ::BHOP_PATTERN_BANKING
+.ifndef bhop_apply_music_bank
 .import bhop_apply_music_bank
+.endif
 BHOP_PATTERN_SWITCH_ROUTINE = bhop_apply_music_bank
 .endif
 
@@ -38,7 +40,9 @@ BHOP_PATTERN_SWITCH_ROUTINE = bhop_apply_music_bank
 __bool_option BHOP_DPCM_BANKING
 
 .if ::BHOP_DPCM_BANKING
+.ifndef bhop_apply_dpcm_bank
 .import bhop_apply_dpcm_bank
+.endif
 BHOP_DPCM_SWITCH_ROUTINE = bhop_apply_dpcm_bank
 .endif
 

--- a/bhop/option_util.inc
+++ b/bhop/option_util.inc
@@ -1,0 +1,53 @@
+.ifndef _OPTION_UTIL_INC
+_OPTION_UTIL_INC = 1
+.macro __bool_option name, default
+.local DefaultVal
+  .ifnblank default
+  DefaultVal .set default
+  .else
+  DefaultVal .set 0
+  .endif
+  .if .not .defined(.ident(.string(name)))
+    .ident(.string(name)) .set DefaultVal
+  .elseif .not ((.ident(.string(name))=1) .or (.ident(.string(name))=0))
+    ; if you get this error then you've set a boolean config option to something other than 0 or 1
+    .error .sprintf("Boolean Option `%s` was set to a value other than 0 or 1", .string(name))
+    .fatal "Invalid Options selected"
+  .endif
+  .ifdef PRINT_OPTIONS_FOR_C
+    .if PRINT_OPTIONS_FOR_C
+      .out .sprintf("#ifndef %s", .string(name))
+      .out .sprintf("  #define %s %d", .string(name), DefaultVal)
+      .out "#endif"
+    .endif
+  .endif
+.endmacro
+
+.macro __num_option name, default
+; work around to check if something is numeric
+.local Num, DefaultVal
+Num = 123
+  .ifnblank default
+  DefaultVal .set default
+  .else
+  DefaultVal .set 0
+  .endif
+  .if .not .defined(.ident(.string(name)))
+    .ident(.string(name)) .set DefaultVal
+    ; Check if its numeric
+    ; match only checks that the types are the same between the two tokens.
+  .elseif .not ( .match ( {.ident(.string(name))}, Num ) )
+    ; if you get this error then you've set a numeric config option to something other than a number
+    .error .sprintf("Number Option `%s` was set to a non numeric value %d", .string(name), .ident(.string(name)))
+    .fatal "Invalid Options selected"
+  .endif
+  .ifdef PRINT_OPTIONS_FOR_C
+    .if PRINT_OPTIONS_FOR_C
+      .out .sprintf("#ifndef %s", .string(name))
+      .out .sprintf("  #define %s %d", .string(name), DefaultVal)
+      .out "#endif"
+    .endif
+  .endif
+.endmacro
+
+.endif


### PR DESCRIPTION
In a project I'm working on, I have a completely separate configuration system and it'll be quite painful if users of my project would need to track down this file and edit it. These changes add a few macros that essentially boil down to "ifndef, use default" such that all options are guaranteed to always exist. This lets a user provides an external value, while also doing some minimal validation on the type of the value provided.

Side note: if `PRINT_OPTIONS_FOR_C = 1` then it will output the equivalent C code for the options in case you ever wanted to support C. (it really helps if your editor supports highlighting defines so that your options are appropriately parsed)